### PR TITLE
Correct mistake in incidence equation

### DIFF
--- a/time.qmd
+++ b/time.qmd
@@ -126,7 +126,7 @@ sir <- odin({
   deriv(S) <- -beta * S * I / N
   deriv(I) <- beta * S * I / N - gamma * I
   deriv(R) <- gamma * I
-  deriv(incidence) <- incidence + beta * S * I / N
+  deriv(incidence) <- beta * S * I / N
 
   initial(S) <- N - I0
   initial(I) <- I0


### PR DESCRIPTION
Correct the incidence formula, that is obtained from integrating the new infected from the start of the day